### PR TITLE
don't throw when provided non-string keys

### DIFF
--- a/src/database_wrap.cc
+++ b/src/database_wrap.cc
@@ -11,6 +11,17 @@
 
 using namespace v8;
 
+#define REQUIRE_STRING_ARG(ARG)                           \
+  if (!ARG->IsString()) {                                 \
+    Local<Value> argv[] = {                               \
+      Exception::Error(String::New("Expecting a string")) \
+    };                                                    \
+    NanCallback *cb = new NanCallback(callback);          \
+    cb->Call(1, argv);                                    \
+    delete cb;                                            \
+    NanReturnUndefined();                                 \
+  }
+
 namespace sophia {
   DatabaseWrap::DatabaseWrap() {
   };
@@ -84,7 +95,9 @@ namespace sophia {
     DatabaseWrap* wrap = ObjectWrap::Unwrap<DatabaseWrap>(args.This());
     LD_METHOD_SETUP_COMMON(put, 2, 3)
 
+    REQUIRE_STRING_ARG(args[0]);
     char* key = NanFromV8String(args[0]);
+    REQUIRE_STRING_ARG(args[1]);
     char* value = NanFromV8String(args[1]);
 
     sophia::Set(
@@ -103,6 +116,7 @@ namespace sophia {
     DatabaseWrap* wrap = ObjectWrap::Unwrap<DatabaseWrap>(args.This());
     LD_METHOD_SETUP_COMMON(get, 1, 2);
 
+    REQUIRE_STRING_ARG(args[0]);
     char* key = NanFromV8String(args[0]);
 
     sophia::Get(
@@ -120,6 +134,7 @@ namespace sophia {
     DatabaseWrap* wrap = ObjectWrap::Unwrap<DatabaseWrap>(args.This());
     LD_METHOD_SETUP_COMMON(get, 1, 2);
 
+    REQUIRE_STRING_ARG(args[0]);
     char* key = NanFromV8String(args[0]);
 
     sophia::Del(

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -33,5 +33,21 @@ test('sophia', function (t) {
         t.end();
       });
     });
+
+    t.test('require strings', function (t) {
+      db.put(1, 2, function (err) {
+        t.ok(err);
+        t.equal(err.message, 'Expecting a string');
+        db.get(3, function (err) {
+          t.ok(err);
+          t.equal(err.message, 'Expecting a string');
+          db.del(4, function (err) {
+            t.ok(err);
+            t.equal(err.message, 'Expecting a string');
+            t.end();
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
pass an error to the callback instead
